### PR TITLE
Add .gitignore for data and PDF files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Data files
+*.csv
+*.xlsx
+*.xls
+*.sav
+*.dta
+*.dat
+*.json
+*.xml
+
+# PDF files
+*.pdf
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Python
+__pycache__/
+*.pyc
+.env
+.venv/


### PR DESCRIPTION
Ignore common data file formats (.csv, .xlsx, .sav, .dta, etc.) and PDF files.