### PR TITLE
Remove original scale item references from MEASURES.md

### DIFF
--- a/MEASURES.md
+++ b/MEASURES.md
@@ -1,7 +1,6 @@
 # Measures Registry
 
 Use this file as the canonical registry for all constructs, instruments, coding rules, and operationalization decisions used in the project.
-Use `/home/ykyan/clawd/memory/scales_and_measures.md` to find original scale items or question wording when the project uses an existing measure.
 
 ## Summary
 
@@ -20,43 +19,10 @@ Use `/home/ykyan/clawd/memory/scales_and_measures.md` to find original scale ite
 ### 1. Construct Name
 
 - Variable name:
-- Related hypothesis:
-- Original source:
-- Citation:
-- Measure type: survey / archival / experiment / coding / behavioral / other
-- Conceptual definition:
-- Operational definition:
-- Original scale item location: `/home/ykyan/clawd/memory/scales_and_measures.md`
-- Item wording or coding basis:
-- Response scale / anchors:
-- Reverse-coded items:
-- Composite or aggregation rule:
-- Missing-data rule:
-- Sample or wave used:
-- Reliability evidence:
-- Validity evidence:
-- Analysis file reference:
-- Raw data field reference:
-- Notes:
+- Original scale item: 
+
 
 ### 2. Construct Name
 
 - Variable name:
-- Related hypothesis:
-- Original source:
-- Citation:
-- Measure type:
-- Conceptual definition:
-- Operational definition:
-- Original scale item location: `/home/ykyan/clawd/memory/scales_and_measures.md`
-- Item wording or coding basis:
-- Response scale / anchors:
-- Reverse-coded items:
-- Composite or aggregation rule:
-- Missing-data rule:
-- Sample or wave used:
-- Reliability evidence:
-- Validity evidence:
-- Analysis file reference:
-- Raw data field reference:
-- Notes:
+- Original scale item: 


### PR DESCRIPTION
Removed references to original scale item locations and related details for constructs.